### PR TITLE
fix: add package-lock.json for cache key + cache boolean input

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Installs the latest Angular CLI on Node 22 with npm caching. Zero config.
 | `node-version` | `22` | Node.js version — e.g. `22`, `20`, `18` |
 | `package-manager` | `npm` | `npm`, `yarn`, or `pnpm` |
 | `cache-dependency-path` | _(repo root)_ | Lock file path for monorepos |
+| `cache` | `true` | Set to `false` to disable package manager caching |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: 'Path to the lock file for caching (e.g. packages/app/package-lock.json). Defaults to repo root.'
     required: false
     default: ''
+  cache:
+    description: 'Enable package manager caching. Set to false to disable (e.g. if no lock file exists).'
+    required: false
+    default: 'true'
 
 outputs:
   cli-version:
@@ -41,7 +45,7 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
-        cache: ${{ inputs.package-manager }}
+        cache: ${{ inputs.cache == 'true' && inputs.package-manager || '' }}
         cache-dependency-path: ${{ inputs.cache-dependency-path }}
 
     - name: Install Angular CLI (npm)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "angular-setup",
+  "version": "2.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "angular-setup",
+      "version": "2.0.0",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "angular-setup",
+  "version": "2.0.0",
+  "description": "GitHub Action: setup Node.js, cache npm/yarn/pnpm, and install Angular CLI",
+  "private": true,
+  "author": "Mayur Rawte <rawte.mayur@gmail.com>",
+  "license": "MIT"
+}


### PR DESCRIPTION
## Root cause

`actions/setup-node@v4` with `cache: npm` (or yarn/pnpm) requires a lock file to build the cache key. We deleted `package.json`/`package-lock.json` in v2, so all test jobs failed with:

```
Dependencies lock file is not found. Supported file patterns: package-lock.json,npm-shrinkwrap.json,yarn.lock
```

## Fix

- Added minimal `package.json` + generated `package-lock.json` back to the repo (no dependencies, just metadata)
- Added `cache` boolean input to `action.yml` (default: `true`) — lets users disable caching when they have no lock file
- Cache is now conditionally passed to `actions/setup-node`: `cache == 'true' && package-manager || ''`
- Updated README inputs table