### PR TITLE
fix: pnpm global bin PATH + pipefail-safe version detection

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,7 +56,9 @@ runs:
     - name: Install Angular CLI (pnpm)
       if: ${{ inputs.package-manager == 'pnpm' }}
       shell: bash
-      run: pnpm add -g @angular/cli@${{ inputs.version }}
+      run: |
+        pnpm add -g @angular/cli@${{ inputs.version }}
+        echo "$(pnpm bin -g)" >> "$GITHUB_PATH"
 
     - name: Install Angular CLI (yarn)
       if: ${{ inputs.package-manager == 'yarn' }}
@@ -69,5 +71,5 @@ runs:
       id: get-version
       shell: bash
       run: |
-        CLI_VERSION=$(ng version 2>/dev/null | grep -i 'Angular CLI:' | awk '{print $NF}')
+        CLI_VERSION=$(ng version 2>/dev/null | grep -i 'Angular CLI:' | awk '{print $NF}' || true)
         echo "cli-version=${CLI_VERSION:-unknown}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Two final test failures:

**1. pnpm global bin not on PATH**
`pnpm add -g` installs to `$(pnpm bin -g)` (e.g. `~/.local/share/pnpm`) but that directory wasn't added to PATH.
Fix: append `$(pnpm bin -g)` to `$GITHUB_PATH` after install — same pattern as yarn.

**2. version detection exits code 1 under pipefail**
The shell runs with `-e -o pipefail`. `grep` exits code 1 when it finds no match, which killed the whole step via pipefail.
Fix: append `|| true` to the pipeline so it always exits 0; the `${:-unknown}` fallback then handles empty output.